### PR TITLE
Change renderer selection

### DIFF
--- a/lib/octopress-code-highlighter/renderer.rb
+++ b/lib/octopress-code-highlighter/renderer.rb
@@ -20,12 +20,12 @@ module Octopress
 
       def select_renderer
         case true
-          when renderer_available?('rouge')
-            require 'rouge'
-            return  'rouge'
           when renderer_available?('pygments.rb')
             require 'pygments'
             return  'pygments'
+          when renderer_available?('rouge')
+            require 'rouge'
+            return  'rouge'
         else
           $stderr.puts 'No syntax highlighting:'.yellow
           $stderr.puts "\tInstall pygments.rb, rouge".yellow


### PR DESCRIPTION
As of https://github.com/jekyll/jekyll/pull/3323 jekyll has a dependency on rouge. Hence, rouge is always used even if pygments is optionally installed.
This patch reverse the loopup of the renderers (previously, first check for rouge, then pygments; now: first check fir pygments, then rouge) so pygments can be used if desired.
